### PR TITLE
fix: Enable Remote Pack Application

### DIFF
--- a/.github/actions/apply-pack/action.yml
+++ b/.github/actions/apply-pack/action.yml
@@ -9,6 +9,10 @@ inputs:
   pack_version:
     description: 'Pack version or ref to apply'
     required: false
+  pack_root:
+    description: 'Root directory of the pack source'
+    required: false
+    default: '.'
   pack_components:
     description: 'Comma-separated list of pack components to apply'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -105,6 +105,7 @@ async function run() {
     try {
         const repo = core.getInput('repo', { required: true });
         const packVersion = core.getInput('pack_version');
+        const packRoot = core.getInput('pack_root') || process.cwd();
         const packComponents = parseComponents(core.getInput('pack_components'));
         const configPath = core.getInput('config_path') || '.github/agentops-pack.yml';
         const apply = parseBoolean(core.getInput('apply'), false);
@@ -146,7 +147,7 @@ async function run() {
             permissionsMode: mergeResult.config.permissionsMode,
             unknownFields: mergeResult.unknownFields,
         };
-        const source = (0, source_1.loadPackSource)(process.cwd(), summary.components);
+        const source = (0, source_1.loadPackSource)(packRoot, summary.components);
         source.warnings.forEach((warning) => core.warning(warning));
         const applyResult = (0, engine_1.applyPackFiles)(process.cwd(), source.files, {
             mode: summary.apply ? 'apply' : 'dry-run',

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ async function run(): Promise<void> {
   try {
     const repo = core.getInput('repo', { required: true });
     const packVersion = core.getInput('pack_version');
+    const packRoot = core.getInput('pack_root') || process.cwd();
     const packComponents = parseComponents(core.getInput('pack_components'));
     const configPath = core.getInput('config_path') || '.github/agentops-pack.yml';
     const apply = parseBoolean(core.getInput('apply'), false);
@@ -132,7 +133,7 @@ async function run(): Promise<void> {
       unknownFields: mergeResult.unknownFields,
     };
 
-    const source = loadPackSource(process.cwd(), summary.components);
+    const source = loadPackSource(packRoot, summary.components);
     source.warnings.forEach((warning) => core.warning(warning));
 
     const applyResult = applyPackFiles(process.cwd(), source.files, {


### PR DESCRIPTION
Introduces pack_root input to separate pack source from target repo CWD. Essential for cross-repo application.